### PR TITLE
Update Go version to 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
       - name: Vet
         run: go vet ./...
       - name: Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:1.22-alpine AS build
+FROM golang:1.23-alpine AS build
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
## Summary
- use `golang:1.23-alpine` in Dockerfile
- configure CI to install Go 1.23

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c3317cf188330b96e41b42da2b16e