### PR TITLE
Update EnsureDNSRecord to support update

### DIFF
--- a/dns/dns.go
+++ b/dns/dns.go
@@ -10,20 +10,46 @@ import (
 type API interface {
 	ZoneIDByName(zoneName string) (string, error)
 	CreateDNSRecord(ctx context.Context, rc *cloudflare.ResourceContainer, params cloudflare.CreateDNSRecordParams) (cloudflare.DNSRecord, error)
+	ListDNSRecords(ctx context.Context, rc *cloudflare.ResourceContainer, params cloudflare.ListDNSRecordsParams) ([]cloudflare.DNSRecord, *cloudflare.ResultInfo, error)
+	UpdateDNSRecord(ctx context.Context, rc *cloudflare.ResourceContainer, params cloudflare.UpdateDNSRecordParams) (cloudflare.DNSRecord, error)
 }
 
-// EnsureDNSRecord creates a DNS record for the given zone.
+// EnsureDNSRecord creates or updates a DNS record for the given zone.
 func EnsureDNSRecord(ctx context.Context, api API, zoneName, recordType, recordName, content string, ttl int) error {
 	zoneID, err := api.ZoneIDByName(zoneName)
 	if err != nil {
 		return err
 	}
-	record := cloudflare.CreateDNSRecordParams{
+
+	// See if a record already exists with the given name and type.
+	records, _, err := api.ListDNSRecords(ctx, cloudflare.ZoneIdentifier(zoneID), cloudflare.ListDNSRecordsParams{
+		Type: recordType,
+		Name: recordName,
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(records) > 0 {
+		// Update the first matched record
+		update := cloudflare.UpdateDNSRecordParams{
+			ID:      records[0].ID,
+			Type:    recordType,
+			Name:    recordName,
+			Content: content,
+			TTL:     ttl,
+		}
+		_, err = api.UpdateDNSRecord(ctx, cloudflare.ZoneIdentifier(zoneID), update)
+		return err
+	}
+
+	// Record does not exist, create it
+	create := cloudflare.CreateDNSRecordParams{
 		Type:    recordType,
 		Name:    recordName,
 		Content: content,
 		TTL:     ttl,
 	}
-	_, err = api.CreateDNSRecord(ctx, cloudflare.ZoneIdentifier(zoneID), record)
+	_, err = api.CreateDNSRecord(ctx, cloudflare.ZoneIdentifier(zoneID), create)
 	return err
 }

--- a/dns/dns_test.go
+++ b/dns/dns_test.go
@@ -10,9 +10,11 @@ import (
 
 // fakeAPI is a simple mock of the Cloudflare API interface.
 type fakeAPI struct {
-	zoneID    string
-	record    cloudflare.CreateDNSRecordParams
-	returnErr error
+	zoneID       string
+	createRecord cloudflare.CreateDNSRecordParams
+	updateRecord cloudflare.UpdateDNSRecordParams
+	listRecords  []cloudflare.DNSRecord
+	returnErr    error
 }
 
 func (f *fakeAPI) ZoneIDByName(name string) (string, error) {
@@ -26,18 +28,53 @@ func (f *fakeAPI) CreateDNSRecord(ctx context.Context, rc *cloudflare.ResourceCo
 	if f.returnErr != nil {
 		return cloudflare.DNSRecord{}, f.returnErr
 	}
-	f.record = params
+	f.createRecord = params
 	return cloudflare.DNSRecord{ID: "123"}, nil
 }
 
-func TestEnsureDNSRecord(t *testing.T) {
+func (f *fakeAPI) ListDNSRecords(ctx context.Context, rc *cloudflare.ResourceContainer, params cloudflare.ListDNSRecordsParams) ([]cloudflare.DNSRecord, *cloudflare.ResultInfo, error) {
+	if f.returnErr != nil {
+		return nil, nil, f.returnErr
+	}
+	return f.listRecords, nil, nil
+}
+
+func (f *fakeAPI) UpdateDNSRecord(ctx context.Context, rc *cloudflare.ResourceContainer, params cloudflare.UpdateDNSRecordParams) (cloudflare.DNSRecord, error) {
+	if f.returnErr != nil {
+		return cloudflare.DNSRecord{}, f.returnErr
+	}
+	f.updateRecord = params
+	return cloudflare.DNSRecord{ID: params.ID}, nil
+}
+
+func TestEnsureDNSRecordCreate(t *testing.T) {
 	f := &fakeAPI{zoneID: "zone123"}
 	err := EnsureDNSRecord(context.Background(), f, "example.com", "A", "test.example.com", "1.2.3.4", 120)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if f.record.Name != "test.example.com" || f.record.Content != "1.2.3.4" || f.record.TTL != 120 {
-		t.Fatalf("unexpected record: %+v", f.record)
+	if f.createRecord.Name != "test.example.com" || f.createRecord.Content != "1.2.3.4" || f.createRecord.TTL != 120 {
+		t.Fatalf("unexpected record: %+v", f.createRecord)
+	}
+	if f.updateRecord.ID != "" {
+		t.Fatalf("unexpected update: %+v", f.updateRecord)
+	}
+}
+
+func TestEnsureDNSRecordUpdate(t *testing.T) {
+	f := &fakeAPI{
+		zoneID:      "zone123",
+		listRecords: []cloudflare.DNSRecord{{ID: "abc", Name: "test.example.com", Type: "A"}},
+	}
+	err := EnsureDNSRecord(context.Background(), f, "example.com", "A", "test.example.com", "2.2.2.2", 60)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if f.updateRecord.ID != "abc" || f.updateRecord.Content != "2.2.2.2" || f.updateRecord.TTL != 60 {
+		t.Fatalf("unexpected update: %+v", f.updateRecord)
+	}
+	if f.createRecord.Name != "" {
+		t.Fatalf("unexpected create: %+v", f.createRecord)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `ListDNSRecords` and `UpdateDNSRecord` to the DNS API interface
- update `EnsureDNSRecord` to update an existing DNS record when found
- expand unit tests for create vs update logic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c395437b483308d98ac308d58755e