### PR TITLE
Update Go build version to 1.24.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ env:
   APP_VERSION: 1.0.${{github.run_number}}
   CONTAINER_IMAGE_NAME: set-cloudflare-dns:1.0.${{github.run_number}}
   PACKAGE_PATH: github.com/danesparza/set-cloudflare-dns
-  GO_VERSION: 1.24.0
+  GO_VERSION: 1.24.4
 
 jobs:
   vulnerabilitycheck:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile References: https://docs.docker.com/engine/reference/builder/
 # Start from the latest golang base image
-FROM --platform=$BUILDPLATFORM golang:1.24.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.4 AS builder
 
 ARG packagePath
 ARG buildNum


### PR DESCRIPTION
## Summary
- update Dockerfile to use golang:1.24.4
- bump CI workflow to Go 1.24.4

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c87df64208330a134b923b878f731